### PR TITLE
Trying to make things a little faster

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -72,14 +72,15 @@ jschardet.VERSION = "0.1";
 jschardet.detect = function(buffer) {
     var u = new jschardet.UniversalDetector();
     u.reset();
-    if( typeof Buffer == 'function' && buffer instanceof Buffer ) {
+    /*if( typeof Buffer == 'function' && buffer instanceof Buffer ) {
         var str = "";
         for (var i = 0; i < buffer.length; ++i)
             str += String.fromCharCode(buffer[i])
         u.feed(str);
     } else {
         u.feed(buffer);
-    }
+    }*/
+    u.feed(typeof Buffer == 'function' && buffer instanceof Buffer ? buffer.toString('binary') : buffer);
     u.close();
     return u.result;
 }


### PR DESCRIPTION
It's a very slight improvement, but it's still one (in my tests, for large buffers, the previous conversion took 150ms vs 2ms in the new version)
The real slow thing is the sbcsgroupprober and the mbcs groupprober