### PR TITLE
Remove module.parent.export syntax

### DIFF
--- a/src/big5freq.js
+++ b/src/big5freq.js
@@ -926,4 +926,4 @@ jschardet.Big5CharToFreqOrder = [
 13952,13953,13954,13955,13956,13957,13958,13959,13960,13961,13962,13963,13964,13965,13966,13967, //13968
 13968,13969,13970,13971,13972]; //13973
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/big5prober.js
+++ b/src/big5prober.js
@@ -48,4 +48,4 @@ jschardet.Big5Prober = function() {
 }
 jschardet.Big5Prober.prototype = new jschardet.MultiByteCharSetProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/chardistribution.js
+++ b/src/chardistribution.js
@@ -280,4 +280,4 @@ jschardet.EUCJPDistributionAnalysis = function() {
 }
 jschardet.EUCJPDistributionAnalysis.prototype = new jschardet.CharDistributionAnalysis();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/charsetgroupprober.js
+++ b/src/charsetgroupprober.js
@@ -115,4 +115,4 @@ jschardet.CharSetGroupProber = function() {
 }
 jschardet.CharSetGroupProber.prototype = new jschardet.CharSetProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/charsetprober.js
+++ b/src/charsetprober.js
@@ -65,4 +65,4 @@ jschardet.CharSetProber = function() {
     }
 }
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/codingstatemachine.js
+++ b/src/codingstatemachine.js
@@ -68,4 +68,4 @@ jschardet.CodingStateMachine = function(sm) {
     init(sm);
 }
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/constants.js
+++ b/src/constants.js
@@ -43,4 +43,4 @@ jschardet.Constants = {
     SHORTCUT_THRESHOLD  : 0.95
 };
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/escprober.js
+++ b/src/escprober.js
@@ -95,4 +95,4 @@ jschardet.EscCharSetProber = function() {
 }
 jschardet.EscCharSetProber.prototype = new jschardet.CharSetProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/escsm.js
+++ b/src/escsm.js
@@ -15,12 +15,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- *
+ * 
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -28,54 +28,54 @@
  */
 
 !function(jschardet) {
-
+    
 jschardet.HZ_cls = [
-    1,0,0,0,0,0,0,0,  // 00 - 07
-    0,0,0,0,0,0,0,0,  // 08 - 0f
-    0,0,0,0,0,0,0,0,  // 10 - 17
-    0,0,0,1,0,0,0,0,  // 18 - 1f
-    0,0,0,0,0,0,0,0,  // 20 - 27
-    0,0,0,0,0,0,0,0,  // 28 - 2f
-    0,0,0,0,0,0,0,0,  // 30 - 37
-    0,0,0,0,0,0,0,0,  // 38 - 3f
-    0,0,0,0,0,0,0,0,  // 40 - 47
-    0,0,0,0,0,0,0,0,  // 48 - 4f
-    0,0,0,0,0,0,0,0,  // 50 - 57
-    0,0,0,0,0,0,0,0,  // 58 - 5f
-    0,0,0,0,0,0,0,0,  // 60 - 67
-    0,0,0,0,0,0,0,0,  // 68 - 6f
-    0,0,0,0,0,0,0,0,  // 70 - 77
-    0,0,0,4,0,5,2,0,  // 78 - 7f
-    1,1,1,1,1,1,1,1,  // 80 - 87
-    1,1,1,1,1,1,1,1,  // 88 - 8f
-    1,1,1,1,1,1,1,1,  // 90 - 97
-    1,1,1,1,1,1,1,1,  // 98 - 9f
-    1,1,1,1,1,1,1,1,  // a0 - a7
-    1,1,1,1,1,1,1,1,  // a8 - af
-    1,1,1,1,1,1,1,1,  // b0 - b7
-    1,1,1,1,1,1,1,1,  // b8 - bf
-    1,1,1,1,1,1,1,1,  // c0 - c7
-    1,1,1,1,1,1,1,1,  // c8 - cf
-    1,1,1,1,1,1,1,1,  // d0 - d7
-    1,1,1,1,1,1,1,1,  // d8 - df
-    1,1,1,1,1,1,1,1,  // e0 - e7
-    1,1,1,1,1,1,1,1,  // e8 - ef
-    1,1,1,1,1,1,1,1,  // f0 - f7
-    1,1,1,1,1,1,1,1   // f8 - ff
+    1,0,0,0,0,0,0,0,  // 00 - 07 
+    0,0,0,0,0,0,0,0,  // 08 - 0f 
+    0,0,0,0,0,0,0,0,  // 10 - 17 
+    0,0,0,1,0,0,0,0,  // 18 - 1f 
+    0,0,0,0,0,0,0,0,  // 20 - 27 
+    0,0,0,0,0,0,0,0,  // 28 - 2f 
+    0,0,0,0,0,0,0,0,  // 30 - 37 
+    0,0,0,0,0,0,0,0,  // 38 - 3f 
+    0,0,0,0,0,0,0,0,  // 40 - 47 
+    0,0,0,0,0,0,0,0,  // 48 - 4f 
+    0,0,0,0,0,0,0,0,  // 50 - 57 
+    0,0,0,0,0,0,0,0,  // 58 - 5f 
+    0,0,0,0,0,0,0,0,  // 60 - 67 
+    0,0,0,0,0,0,0,0,  // 68 - 6f 
+    0,0,0,0,0,0,0,0,  // 70 - 77 
+    0,0,0,4,0,5,2,0,  // 78 - 7f 
+    1,1,1,1,1,1,1,1,  // 80 - 87 
+    1,1,1,1,1,1,1,1,  // 88 - 8f 
+    1,1,1,1,1,1,1,1,  // 90 - 97 
+    1,1,1,1,1,1,1,1,  // 98 - 9f 
+    1,1,1,1,1,1,1,1,  // a0 - a7 
+    1,1,1,1,1,1,1,1,  // a8 - af 
+    1,1,1,1,1,1,1,1,  // b0 - b7 
+    1,1,1,1,1,1,1,1,  // b8 - bf 
+    1,1,1,1,1,1,1,1,  // c0 - c7 
+    1,1,1,1,1,1,1,1,  // c8 - cf 
+    1,1,1,1,1,1,1,1,  // d0 - d7 
+    1,1,1,1,1,1,1,1,  // d8 - df 
+    1,1,1,1,1,1,1,1,  // e0 - e7 
+    1,1,1,1,1,1,1,1,  // e8 - ef 
+    1,1,1,1,1,1,1,1,  // f0 - f7 
+    1,1,1,1,1,1,1,1   // f8 - ff 
 ];
 
 with( jschardet.Constants )
 jschardet.HZ_st = [
-    start,error,    3,start,start,start,error,error, // 00-07
-    error,error,error,error,itsMe,itsMe,itsMe,itsMe, // 08-0f
-    itsMe,itsMe,error,error,start,start,    4,error, // 10-17
-        5,error,    6,error,    5,    5,    4,error, // 18-1f
-        4,error,    4,    4,    4,error,    4,error, // 20-27
-        4,itsMe,start,start,start,start,start,start  // 28-2f
+    start,error,    3,start,start,start,error,error, // 00-07 
+    error,error,error,error,itsMe,itsMe,itsMe,itsMe, // 08-0f 
+    itsMe,itsMe,error,error,start,start,    4,error, // 10-17 
+        5,error,    6,error,    5,    5,    4,error, // 18-1f 
+        4,error,    4,    4,    4,error,    4,error, // 20-27 
+        4,itsMe,start,start,start,start,start,start  // 28-2f 
 ];
-
+    
 jschardet.HZCharLenTable = [0, 0, 0, 0, 0, 0];
-
+    
 jschardet.HZSMModel = {
     "classTable"    : jschardet.HZ_cls,
     "classFactor"   : 6,
@@ -85,50 +85,50 @@ jschardet.HZSMModel = {
 };
 
 jschardet.ISO2022CN_cls = [
-    2,0,0,0,0,0,0,0,  // 00 - 07
-    0,0,0,0,0,0,0,0,  // 08 - 0f
-    0,0,0,0,0,0,0,0,  // 10 - 17
-    0,0,0,1,0,0,0,0,  // 18 - 1f
-    0,0,0,0,0,0,0,0,  // 20 - 27
-    0,3,0,0,0,0,0,0,  // 28 - 2f
-    0,0,0,0,0,0,0,0,  // 30 - 37
-    0,0,0,0,0,0,0,0,  // 38 - 3f
-    0,0,0,4,0,0,0,0,  // 40 - 47
-    0,0,0,0,0,0,0,0,  // 48 - 4f
-    0,0,0,0,0,0,0,0,  // 50 - 57
-    0,0,0,0,0,0,0,0,  // 58 - 5f
-    0,0,0,0,0,0,0,0,  // 60 - 67
-    0,0,0,0,0,0,0,0,  // 68 - 6f
-    0,0,0,0,0,0,0,0,  // 70 - 77
-    0,0,0,0,0,0,0,0,  // 78 - 7f
-    2,2,2,2,2,2,2,2,  // 80 - 87
-    2,2,2,2,2,2,2,2,  // 88 - 8f
-    2,2,2,2,2,2,2,2,  // 90 - 97
-    2,2,2,2,2,2,2,2,  // 98 - 9f
-    2,2,2,2,2,2,2,2,  // a0 - a7
-    2,2,2,2,2,2,2,2,  // a8 - af
-    2,2,2,2,2,2,2,2,  // b0 - b7
-    2,2,2,2,2,2,2,2,  // b8 - bf
-    2,2,2,2,2,2,2,2,  // c0 - c7
-    2,2,2,2,2,2,2,2,  // c8 - cf
-    2,2,2,2,2,2,2,2,  // d0 - d7
-    2,2,2,2,2,2,2,2,  // d8 - df
-    2,2,2,2,2,2,2,2,  // e0 - e7
-    2,2,2,2,2,2,2,2,  // e8 - ef
-    2,2,2,2,2,2,2,2,  // f0 - f7
-    2,2,2,2,2,2,2,2   // f8 - ff
+    2,0,0,0,0,0,0,0,  // 00 - 07 
+    0,0,0,0,0,0,0,0,  // 08 - 0f 
+    0,0,0,0,0,0,0,0,  // 10 - 17 
+    0,0,0,1,0,0,0,0,  // 18 - 1f 
+    0,0,0,0,0,0,0,0,  // 20 - 27 
+    0,3,0,0,0,0,0,0,  // 28 - 2f 
+    0,0,0,0,0,0,0,0,  // 30 - 37 
+    0,0,0,0,0,0,0,0,  // 38 - 3f 
+    0,0,0,4,0,0,0,0,  // 40 - 47 
+    0,0,0,0,0,0,0,0,  // 48 - 4f 
+    0,0,0,0,0,0,0,0,  // 50 - 57 
+    0,0,0,0,0,0,0,0,  // 58 - 5f 
+    0,0,0,0,0,0,0,0,  // 60 - 67 
+    0,0,0,0,0,0,0,0,  // 68 - 6f 
+    0,0,0,0,0,0,0,0,  // 70 - 77 
+    0,0,0,0,0,0,0,0,  // 78 - 7f 
+    2,2,2,2,2,2,2,2,  // 80 - 87 
+    2,2,2,2,2,2,2,2,  // 88 - 8f 
+    2,2,2,2,2,2,2,2,  // 90 - 97 
+    2,2,2,2,2,2,2,2,  // 98 - 9f 
+    2,2,2,2,2,2,2,2,  // a0 - a7 
+    2,2,2,2,2,2,2,2,  // a8 - af 
+    2,2,2,2,2,2,2,2,  // b0 - b7 
+    2,2,2,2,2,2,2,2,  // b8 - bf 
+    2,2,2,2,2,2,2,2,  // c0 - c7 
+    2,2,2,2,2,2,2,2,  // c8 - cf 
+    2,2,2,2,2,2,2,2,  // d0 - d7 
+    2,2,2,2,2,2,2,2,  // d8 - df 
+    2,2,2,2,2,2,2,2,  // e0 - e7 
+    2,2,2,2,2,2,2,2,  // e8 - ef 
+    2,2,2,2,2,2,2,2,  // f0 - f7 
+    2,2,2,2,2,2,2,2   // f8 - ff 
 ];
 
 with( jschardet.Constants )
 jschardet.ISO2022CN_st = [
-    start,    3,error,start,start,start,start,start, // 00-07
-    start,error,error,error,error,error,error,error, // 08-0f
-    error,error,itsMe,itsMe,itsMe,itsMe,itsMe,itsMe, // 10-17
-    itsMe,itsMe,itsMe,error,error,error,    4,error, // 18-1f
-    error,error,error,itsMe,error,error,error,error, // 20-27
-        5,    6,error,error,error,error,error,error, // 28-2f
-    error,error,error,itsMe,error,error,error,error, // 30-37
-    error,error,error,error,error,itsMe,error,start  // 38-3f
+    start,    3,error,start,start,start,start,start, // 00-07 
+    start,error,error,error,error,error,error,error, // 08-0f 
+    error,error,itsMe,itsMe,itsMe,itsMe,itsMe,itsMe, // 10-17 
+    itsMe,itsMe,itsMe,error,error,error,    4,error, // 18-1f 
+    error,error,error,itsMe,error,error,error,error, // 20-27 
+        5,    6,error,error,error,error,error,error, // 28-2f 
+    error,error,error,itsMe,error,error,error,error, // 30-37 
+    error,error,error,error,error,itsMe,error,start  // 38-3f 
 ];
 
 jschardet.ISO2022CNCharLenTable = [0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -142,51 +142,51 @@ jschardet.ISO2022CNSMModel = {
 };
 
 jschardet.ISO2022JP_cls = [
-    2,0,0,0,0,0,0,0,  // 00 - 07
-    0,0,0,0,0,0,2,2,  // 08 - 0f
-    0,0,0,0,0,0,0,0,  // 10 - 17
-    0,0,0,1,0,0,0,0,  // 18 - 1f
-    0,0,0,0,7,0,0,0,  // 20 - 27
-    3,0,0,0,0,0,0,0,  // 28 - 2f
-    0,0,0,0,0,0,0,0,  // 30 - 37
-    0,0,0,0,0,0,0,0,  // 38 - 3f
-    6,0,4,0,8,0,0,0,  // 40 - 47
-    0,9,5,0,0,0,0,0,  // 48 - 4f
-    0,0,0,0,0,0,0,0,  // 50 - 57
-    0,0,0,0,0,0,0,0,  // 58 - 5f
-    0,0,0,0,0,0,0,0,  // 60 - 67
-    0,0,0,0,0,0,0,0,  // 68 - 6f
-    0,0,0,0,0,0,0,0,  // 70 - 77
-    0,0,0,0,0,0,0,0,  // 78 - 7f
-    2,2,2,2,2,2,2,2,  // 80 - 87
-    2,2,2,2,2,2,2,2,  // 88 - 8f
-    2,2,2,2,2,2,2,2,  // 90 - 97
-    2,2,2,2,2,2,2,2,  // 98 - 9f
-    2,2,2,2,2,2,2,2,  // a0 - a7
-    2,2,2,2,2,2,2,2,  // a8 - af
-    2,2,2,2,2,2,2,2,  // b0 - b7
-    2,2,2,2,2,2,2,2,  // b8 - bf
-    2,2,2,2,2,2,2,2,  // c0 - c7
-    2,2,2,2,2,2,2,2,  // c8 - cf
-    2,2,2,2,2,2,2,2,  // d0 - d7
-    2,2,2,2,2,2,2,2,  // d8 - df
-    2,2,2,2,2,2,2,2,  // e0 - e7
-    2,2,2,2,2,2,2,2,  // e8 - ef
-    2,2,2,2,2,2,2,2,  // f0 - f7
-    2,2,2,2,2,2,2,2   // f8 - ff
+    2,0,0,0,0,0,0,0,  // 00 - 07 
+    0,0,0,0,0,0,2,2,  // 08 - 0f 
+    0,0,0,0,0,0,0,0,  // 10 - 17 
+    0,0,0,1,0,0,0,0,  // 18 - 1f 
+    0,0,0,0,7,0,0,0,  // 20 - 27 
+    3,0,0,0,0,0,0,0,  // 28 - 2f 
+    0,0,0,0,0,0,0,0,  // 30 - 37 
+    0,0,0,0,0,0,0,0,  // 38 - 3f 
+    6,0,4,0,8,0,0,0,  // 40 - 47 
+    0,9,5,0,0,0,0,0,  // 48 - 4f 
+    0,0,0,0,0,0,0,0,  // 50 - 57 
+    0,0,0,0,0,0,0,0,  // 58 - 5f 
+    0,0,0,0,0,0,0,0,  // 60 - 67 
+    0,0,0,0,0,0,0,0,  // 68 - 6f 
+    0,0,0,0,0,0,0,0,  // 70 - 77 
+    0,0,0,0,0,0,0,0,  // 78 - 7f 
+    2,2,2,2,2,2,2,2,  // 80 - 87 
+    2,2,2,2,2,2,2,2,  // 88 - 8f 
+    2,2,2,2,2,2,2,2,  // 90 - 97 
+    2,2,2,2,2,2,2,2,  // 98 - 9f 
+    2,2,2,2,2,2,2,2,  // a0 - a7 
+    2,2,2,2,2,2,2,2,  // a8 - af 
+    2,2,2,2,2,2,2,2,  // b0 - b7 
+    2,2,2,2,2,2,2,2,  // b8 - bf 
+    2,2,2,2,2,2,2,2,  // c0 - c7 
+    2,2,2,2,2,2,2,2,  // c8 - cf 
+    2,2,2,2,2,2,2,2,  // d0 - d7 
+    2,2,2,2,2,2,2,2,  // d8 - df 
+    2,2,2,2,2,2,2,2,  // e0 - e7 
+    2,2,2,2,2,2,2,2,  // e8 - ef 
+    2,2,2,2,2,2,2,2,  // f0 - f7 
+    2,2,2,2,2,2,2,2   // f8 - ff 
 ];
 
 with( jschardet.Constants )
 jschardet.ISO2022JP_st = [
-    start,    3,error,start,start,start,start,start, // 00-07
-    start,start,error,error,error,error,error,error, // 08-0f
-    error,error,error,error,itsMe,itsMe,itsMe,itsMe, // 10-17
-    itsMe,itsMe,itsMe,itsMe,itsMe,itsMe,error,error, // 18-1f
-    error,    5,error,error,error,    4,error,error, // 20-27
-    error,error,error,    6,itsMe,error,itsMe,error, // 28-2f
-    error,error,error,error,error,error,itsMe,itsMe, // 30-37
-    error,error,error,itsMe,error,error,error,error, // 38-3f
-    error,error,error,error,itsMe,error,start,start  // 40-47
+    start,    3,error,start,start,start,start,start, // 00-07 
+    start,start,error,error,error,error,error,error, // 08-0f 
+    error,error,error,error,itsMe,itsMe,itsMe,itsMe, // 10-17 
+    itsMe,itsMe,itsMe,itsMe,itsMe,itsMe,error,error, // 18-1f 
+    error,    5,error,error,error,    4,error,error, // 20-27 
+    error,error,error,    6,itsMe,error,itsMe,error, // 28-2f 
+    error,error,error,error,error,error,itsMe,itsMe, // 30-37 
+    error,error,error,itsMe,error,error,error,error, // 38-3f 
+    error,error,error,error,itsMe,error,start,start  // 40-47 
 ];
 
 jschardet.ISO2022JPCharLenTable = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -200,47 +200,47 @@ jschardet.ISO2022JPSMModel = {
 };
 
 jschardet.ISO2022KR_cls = [
-    2,0,0,0,0,0,0,0,  // 00 - 07
-    0,0,0,0,0,0,0,0,  // 08 - 0f
-    0,0,0,0,0,0,0,0,  // 10 - 17
-    0,0,0,1,0,0,0,0,  // 18 - 1f
-    0,0,0,0,3,0,0,0,  // 20 - 27
-    0,4,0,0,0,0,0,0,  // 28 - 2f
-    0,0,0,0,0,0,0,0,  // 30 - 37
-    0,0,0,0,0,0,0,0,  // 38 - 3f
-    0,0,0,5,0,0,0,0,  // 40 - 47
-    0,0,0,0,0,0,0,0,  // 48 - 4f
-    0,0,0,0,0,0,0,0,  // 50 - 57
-    0,0,0,0,0,0,0,0,  // 58 - 5f
-    0,0,0,0,0,0,0,0,  // 60 - 67
-    0,0,0,0,0,0,0,0,  // 68 - 6f
-    0,0,0,0,0,0,0,0,  // 70 - 77
-    0,0,0,0,0,0,0,0,  // 78 - 7f
-    2,2,2,2,2,2,2,2,  // 80 - 87
-    2,2,2,2,2,2,2,2,  // 88 - 8f
-    2,2,2,2,2,2,2,2,  // 90 - 97
-    2,2,2,2,2,2,2,2,  // 98 - 9f
-    2,2,2,2,2,2,2,2,  // a0 - a7
-    2,2,2,2,2,2,2,2,  // a8 - af
-    2,2,2,2,2,2,2,2,  // b0 - b7
-    2,2,2,2,2,2,2,2,  // b8 - bf
-    2,2,2,2,2,2,2,2,  // c0 - c7
-    2,2,2,2,2,2,2,2,  // c8 - cf
-    2,2,2,2,2,2,2,2,  // d0 - d7
-    2,2,2,2,2,2,2,2,  // d8 - df
-    2,2,2,2,2,2,2,2,  // e0 - e7
-    2,2,2,2,2,2,2,2,  // e8 - ef
-    2,2,2,2,2,2,2,2,  // f0 - f7
-    2,2,2,2,2,2,2,2   // f8 - ff
+    2,0,0,0,0,0,0,0,  // 00 - 07 
+    0,0,0,0,0,0,0,0,  // 08 - 0f 
+    0,0,0,0,0,0,0,0,  // 10 - 17 
+    0,0,0,1,0,0,0,0,  // 18 - 1f 
+    0,0,0,0,3,0,0,0,  // 20 - 27 
+    0,4,0,0,0,0,0,0,  // 28 - 2f 
+    0,0,0,0,0,0,0,0,  // 30 - 37 
+    0,0,0,0,0,0,0,0,  // 38 - 3f 
+    0,0,0,5,0,0,0,0,  // 40 - 47 
+    0,0,0,0,0,0,0,0,  // 48 - 4f 
+    0,0,0,0,0,0,0,0,  // 50 - 57 
+    0,0,0,0,0,0,0,0,  // 58 - 5f 
+    0,0,0,0,0,0,0,0,  // 60 - 67 
+    0,0,0,0,0,0,0,0,  // 68 - 6f 
+    0,0,0,0,0,0,0,0,  // 70 - 77 
+    0,0,0,0,0,0,0,0,  // 78 - 7f 
+    2,2,2,2,2,2,2,2,  // 80 - 87 
+    2,2,2,2,2,2,2,2,  // 88 - 8f 
+    2,2,2,2,2,2,2,2,  // 90 - 97 
+    2,2,2,2,2,2,2,2,  // 98 - 9f 
+    2,2,2,2,2,2,2,2,  // a0 - a7 
+    2,2,2,2,2,2,2,2,  // a8 - af 
+    2,2,2,2,2,2,2,2,  // b0 - b7 
+    2,2,2,2,2,2,2,2,  // b8 - bf 
+    2,2,2,2,2,2,2,2,  // c0 - c7 
+    2,2,2,2,2,2,2,2,  // c8 - cf 
+    2,2,2,2,2,2,2,2,  // d0 - d7 
+    2,2,2,2,2,2,2,2,  // d8 - df 
+    2,2,2,2,2,2,2,2,  // e0 - e7 
+    2,2,2,2,2,2,2,2,  // e8 - ef 
+    2,2,2,2,2,2,2,2,  // f0 - f7 
+    2,2,2,2,2,2,2,2   // f8 - ff 
 ];
 
 with( jschardet.Constants )
 jschardet.ISO2022KR_st = [
-    start,    3,error,start,start,start,error,error, // 00-07
-    error,error,error,error,itsMe,itsMe,itsMe,itsMe, // 08-0f
-    itsMe,itsMe,error,error,error,    4,error,error, // 10-17
-    error,error,error,error,    5,error,error,error, // 18-1f
-    error,error,error,itsMe,start,start,start,start  // 20-27
+    start,    3,error,start,start,start,error,error, // 00-07 
+    error,error,error,error,itsMe,itsMe,itsMe,itsMe, // 08-0f 
+    itsMe,itsMe,error,error,error,    4,error,error, // 10-17 
+    error,error,error,error,    5,error,error,error, // 18-1f 
+    error,error,error,itsMe,start,start,start,start  // 20-27 
 ];
 
 jschardet.ISO2022KRCharLenTable = [0, 0, 0, 0, 0, 0];

--- a/src/escsm.js
+++ b/src/escsm.js
@@ -15,12 +15,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -28,54 +28,54 @@
  */
 
 !function(jschardet) {
-    
+
 jschardet.HZ_cls = [
-    1,0,0,0,0,0,0,0,  // 00 - 07 
-    0,0,0,0,0,0,0,0,  // 08 - 0f 
-    0,0,0,0,0,0,0,0,  // 10 - 17 
-    0,0,0,1,0,0,0,0,  // 18 - 1f 
-    0,0,0,0,0,0,0,0,  // 20 - 27 
-    0,0,0,0,0,0,0,0,  // 28 - 2f 
-    0,0,0,0,0,0,0,0,  // 30 - 37 
-    0,0,0,0,0,0,0,0,  // 38 - 3f 
-    0,0,0,0,0,0,0,0,  // 40 - 47 
-    0,0,0,0,0,0,0,0,  // 48 - 4f 
-    0,0,0,0,0,0,0,0,  // 50 - 57 
-    0,0,0,0,0,0,0,0,  // 58 - 5f 
-    0,0,0,0,0,0,0,0,  // 60 - 67 
-    0,0,0,0,0,0,0,0,  // 68 - 6f 
-    0,0,0,0,0,0,0,0,  // 70 - 77 
-    0,0,0,4,0,5,2,0,  // 78 - 7f 
-    1,1,1,1,1,1,1,1,  // 80 - 87 
-    1,1,1,1,1,1,1,1,  // 88 - 8f 
-    1,1,1,1,1,1,1,1,  // 90 - 97 
-    1,1,1,1,1,1,1,1,  // 98 - 9f 
-    1,1,1,1,1,1,1,1,  // a0 - a7 
-    1,1,1,1,1,1,1,1,  // a8 - af 
-    1,1,1,1,1,1,1,1,  // b0 - b7 
-    1,1,1,1,1,1,1,1,  // b8 - bf 
-    1,1,1,1,1,1,1,1,  // c0 - c7 
-    1,1,1,1,1,1,1,1,  // c8 - cf 
-    1,1,1,1,1,1,1,1,  // d0 - d7 
-    1,1,1,1,1,1,1,1,  // d8 - df 
-    1,1,1,1,1,1,1,1,  // e0 - e7 
-    1,1,1,1,1,1,1,1,  // e8 - ef 
-    1,1,1,1,1,1,1,1,  // f0 - f7 
-    1,1,1,1,1,1,1,1   // f8 - ff 
+    1,0,0,0,0,0,0,0,  // 00 - 07
+    0,0,0,0,0,0,0,0,  // 08 - 0f
+    0,0,0,0,0,0,0,0,  // 10 - 17
+    0,0,0,1,0,0,0,0,  // 18 - 1f
+    0,0,0,0,0,0,0,0,  // 20 - 27
+    0,0,0,0,0,0,0,0,  // 28 - 2f
+    0,0,0,0,0,0,0,0,  // 30 - 37
+    0,0,0,0,0,0,0,0,  // 38 - 3f
+    0,0,0,0,0,0,0,0,  // 40 - 47
+    0,0,0,0,0,0,0,0,  // 48 - 4f
+    0,0,0,0,0,0,0,0,  // 50 - 57
+    0,0,0,0,0,0,0,0,  // 58 - 5f
+    0,0,0,0,0,0,0,0,  // 60 - 67
+    0,0,0,0,0,0,0,0,  // 68 - 6f
+    0,0,0,0,0,0,0,0,  // 70 - 77
+    0,0,0,4,0,5,2,0,  // 78 - 7f
+    1,1,1,1,1,1,1,1,  // 80 - 87
+    1,1,1,1,1,1,1,1,  // 88 - 8f
+    1,1,1,1,1,1,1,1,  // 90 - 97
+    1,1,1,1,1,1,1,1,  // 98 - 9f
+    1,1,1,1,1,1,1,1,  // a0 - a7
+    1,1,1,1,1,1,1,1,  // a8 - af
+    1,1,1,1,1,1,1,1,  // b0 - b7
+    1,1,1,1,1,1,1,1,  // b8 - bf
+    1,1,1,1,1,1,1,1,  // c0 - c7
+    1,1,1,1,1,1,1,1,  // c8 - cf
+    1,1,1,1,1,1,1,1,  // d0 - d7
+    1,1,1,1,1,1,1,1,  // d8 - df
+    1,1,1,1,1,1,1,1,  // e0 - e7
+    1,1,1,1,1,1,1,1,  // e8 - ef
+    1,1,1,1,1,1,1,1,  // f0 - f7
+    1,1,1,1,1,1,1,1   // f8 - ff
 ];
 
 with( jschardet.Constants )
 jschardet.HZ_st = [
-    start,error,    3,start,start,start,error,error, // 00-07 
-    error,error,error,error,itsMe,itsMe,itsMe,itsMe, // 08-0f 
-    itsMe,itsMe,error,error,start,start,    4,error, // 10-17 
-        5,error,    6,error,    5,    5,    4,error, // 18-1f 
-        4,error,    4,    4,    4,error,    4,error, // 20-27 
-        4,itsMe,start,start,start,start,start,start  // 28-2f 
+    start,error,    3,start,start,start,error,error, // 00-07
+    error,error,error,error,itsMe,itsMe,itsMe,itsMe, // 08-0f
+    itsMe,itsMe,error,error,start,start,    4,error, // 10-17
+        5,error,    6,error,    5,    5,    4,error, // 18-1f
+        4,error,    4,    4,    4,error,    4,error, // 20-27
+        4,itsMe,start,start,start,start,start,start  // 28-2f
 ];
-    
+
 jschardet.HZCharLenTable = [0, 0, 0, 0, 0, 0];
-    
+
 jschardet.HZSMModel = {
     "classTable"    : jschardet.HZ_cls,
     "classFactor"   : 6,
@@ -85,50 +85,50 @@ jschardet.HZSMModel = {
 };
 
 jschardet.ISO2022CN_cls = [
-    2,0,0,0,0,0,0,0,  // 00 - 07 
-    0,0,0,0,0,0,0,0,  // 08 - 0f 
-    0,0,0,0,0,0,0,0,  // 10 - 17 
-    0,0,0,1,0,0,0,0,  // 18 - 1f 
-    0,0,0,0,0,0,0,0,  // 20 - 27 
-    0,3,0,0,0,0,0,0,  // 28 - 2f 
-    0,0,0,0,0,0,0,0,  // 30 - 37 
-    0,0,0,0,0,0,0,0,  // 38 - 3f 
-    0,0,0,4,0,0,0,0,  // 40 - 47 
-    0,0,0,0,0,0,0,0,  // 48 - 4f 
-    0,0,0,0,0,0,0,0,  // 50 - 57 
-    0,0,0,0,0,0,0,0,  // 58 - 5f 
-    0,0,0,0,0,0,0,0,  // 60 - 67 
-    0,0,0,0,0,0,0,0,  // 68 - 6f 
-    0,0,0,0,0,0,0,0,  // 70 - 77 
-    0,0,0,0,0,0,0,0,  // 78 - 7f 
-    2,2,2,2,2,2,2,2,  // 80 - 87 
-    2,2,2,2,2,2,2,2,  // 88 - 8f 
-    2,2,2,2,2,2,2,2,  // 90 - 97 
-    2,2,2,2,2,2,2,2,  // 98 - 9f 
-    2,2,2,2,2,2,2,2,  // a0 - a7 
-    2,2,2,2,2,2,2,2,  // a8 - af 
-    2,2,2,2,2,2,2,2,  // b0 - b7 
-    2,2,2,2,2,2,2,2,  // b8 - bf 
-    2,2,2,2,2,2,2,2,  // c0 - c7 
-    2,2,2,2,2,2,2,2,  // c8 - cf 
-    2,2,2,2,2,2,2,2,  // d0 - d7 
-    2,2,2,2,2,2,2,2,  // d8 - df 
-    2,2,2,2,2,2,2,2,  // e0 - e7 
-    2,2,2,2,2,2,2,2,  // e8 - ef 
-    2,2,2,2,2,2,2,2,  // f0 - f7 
-    2,2,2,2,2,2,2,2   // f8 - ff 
+    2,0,0,0,0,0,0,0,  // 00 - 07
+    0,0,0,0,0,0,0,0,  // 08 - 0f
+    0,0,0,0,0,0,0,0,  // 10 - 17
+    0,0,0,1,0,0,0,0,  // 18 - 1f
+    0,0,0,0,0,0,0,0,  // 20 - 27
+    0,3,0,0,0,0,0,0,  // 28 - 2f
+    0,0,0,0,0,0,0,0,  // 30 - 37
+    0,0,0,0,0,0,0,0,  // 38 - 3f
+    0,0,0,4,0,0,0,0,  // 40 - 47
+    0,0,0,0,0,0,0,0,  // 48 - 4f
+    0,0,0,0,0,0,0,0,  // 50 - 57
+    0,0,0,0,0,0,0,0,  // 58 - 5f
+    0,0,0,0,0,0,0,0,  // 60 - 67
+    0,0,0,0,0,0,0,0,  // 68 - 6f
+    0,0,0,0,0,0,0,0,  // 70 - 77
+    0,0,0,0,0,0,0,0,  // 78 - 7f
+    2,2,2,2,2,2,2,2,  // 80 - 87
+    2,2,2,2,2,2,2,2,  // 88 - 8f
+    2,2,2,2,2,2,2,2,  // 90 - 97
+    2,2,2,2,2,2,2,2,  // 98 - 9f
+    2,2,2,2,2,2,2,2,  // a0 - a7
+    2,2,2,2,2,2,2,2,  // a8 - af
+    2,2,2,2,2,2,2,2,  // b0 - b7
+    2,2,2,2,2,2,2,2,  // b8 - bf
+    2,2,2,2,2,2,2,2,  // c0 - c7
+    2,2,2,2,2,2,2,2,  // c8 - cf
+    2,2,2,2,2,2,2,2,  // d0 - d7
+    2,2,2,2,2,2,2,2,  // d8 - df
+    2,2,2,2,2,2,2,2,  // e0 - e7
+    2,2,2,2,2,2,2,2,  // e8 - ef
+    2,2,2,2,2,2,2,2,  // f0 - f7
+    2,2,2,2,2,2,2,2   // f8 - ff
 ];
 
 with( jschardet.Constants )
 jschardet.ISO2022CN_st = [
-    start,    3,error,start,start,start,start,start, // 00-07 
-    start,error,error,error,error,error,error,error, // 08-0f 
-    error,error,itsMe,itsMe,itsMe,itsMe,itsMe,itsMe, // 10-17 
-    itsMe,itsMe,itsMe,error,error,error,    4,error, // 18-1f 
-    error,error,error,itsMe,error,error,error,error, // 20-27 
-        5,    6,error,error,error,error,error,error, // 28-2f 
-    error,error,error,itsMe,error,error,error,error, // 30-37 
-    error,error,error,error,error,itsMe,error,start  // 38-3f 
+    start,    3,error,start,start,start,start,start, // 00-07
+    start,error,error,error,error,error,error,error, // 08-0f
+    error,error,itsMe,itsMe,itsMe,itsMe,itsMe,itsMe, // 10-17
+    itsMe,itsMe,itsMe,error,error,error,    4,error, // 18-1f
+    error,error,error,itsMe,error,error,error,error, // 20-27
+        5,    6,error,error,error,error,error,error, // 28-2f
+    error,error,error,itsMe,error,error,error,error, // 30-37
+    error,error,error,error,error,itsMe,error,start  // 38-3f
 ];
 
 jschardet.ISO2022CNCharLenTable = [0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -142,51 +142,51 @@ jschardet.ISO2022CNSMModel = {
 };
 
 jschardet.ISO2022JP_cls = [
-    2,0,0,0,0,0,0,0,  // 00 - 07 
-    0,0,0,0,0,0,2,2,  // 08 - 0f 
-    0,0,0,0,0,0,0,0,  // 10 - 17 
-    0,0,0,1,0,0,0,0,  // 18 - 1f 
-    0,0,0,0,7,0,0,0,  // 20 - 27 
-    3,0,0,0,0,0,0,0,  // 28 - 2f 
-    0,0,0,0,0,0,0,0,  // 30 - 37 
-    0,0,0,0,0,0,0,0,  // 38 - 3f 
-    6,0,4,0,8,0,0,0,  // 40 - 47 
-    0,9,5,0,0,0,0,0,  // 48 - 4f 
-    0,0,0,0,0,0,0,0,  // 50 - 57 
-    0,0,0,0,0,0,0,0,  // 58 - 5f 
-    0,0,0,0,0,0,0,0,  // 60 - 67 
-    0,0,0,0,0,0,0,0,  // 68 - 6f 
-    0,0,0,0,0,0,0,0,  // 70 - 77 
-    0,0,0,0,0,0,0,0,  // 78 - 7f 
-    2,2,2,2,2,2,2,2,  // 80 - 87 
-    2,2,2,2,2,2,2,2,  // 88 - 8f 
-    2,2,2,2,2,2,2,2,  // 90 - 97 
-    2,2,2,2,2,2,2,2,  // 98 - 9f 
-    2,2,2,2,2,2,2,2,  // a0 - a7 
-    2,2,2,2,2,2,2,2,  // a8 - af 
-    2,2,2,2,2,2,2,2,  // b0 - b7 
-    2,2,2,2,2,2,2,2,  // b8 - bf 
-    2,2,2,2,2,2,2,2,  // c0 - c7 
-    2,2,2,2,2,2,2,2,  // c8 - cf 
-    2,2,2,2,2,2,2,2,  // d0 - d7 
-    2,2,2,2,2,2,2,2,  // d8 - df 
-    2,2,2,2,2,2,2,2,  // e0 - e7 
-    2,2,2,2,2,2,2,2,  // e8 - ef 
-    2,2,2,2,2,2,2,2,  // f0 - f7 
-    2,2,2,2,2,2,2,2   // f8 - ff 
+    2,0,0,0,0,0,0,0,  // 00 - 07
+    0,0,0,0,0,0,2,2,  // 08 - 0f
+    0,0,0,0,0,0,0,0,  // 10 - 17
+    0,0,0,1,0,0,0,0,  // 18 - 1f
+    0,0,0,0,7,0,0,0,  // 20 - 27
+    3,0,0,0,0,0,0,0,  // 28 - 2f
+    0,0,0,0,0,0,0,0,  // 30 - 37
+    0,0,0,0,0,0,0,0,  // 38 - 3f
+    6,0,4,0,8,0,0,0,  // 40 - 47
+    0,9,5,0,0,0,0,0,  // 48 - 4f
+    0,0,0,0,0,0,0,0,  // 50 - 57
+    0,0,0,0,0,0,0,0,  // 58 - 5f
+    0,0,0,0,0,0,0,0,  // 60 - 67
+    0,0,0,0,0,0,0,0,  // 68 - 6f
+    0,0,0,0,0,0,0,0,  // 70 - 77
+    0,0,0,0,0,0,0,0,  // 78 - 7f
+    2,2,2,2,2,2,2,2,  // 80 - 87
+    2,2,2,2,2,2,2,2,  // 88 - 8f
+    2,2,2,2,2,2,2,2,  // 90 - 97
+    2,2,2,2,2,2,2,2,  // 98 - 9f
+    2,2,2,2,2,2,2,2,  // a0 - a7
+    2,2,2,2,2,2,2,2,  // a8 - af
+    2,2,2,2,2,2,2,2,  // b0 - b7
+    2,2,2,2,2,2,2,2,  // b8 - bf
+    2,2,2,2,2,2,2,2,  // c0 - c7
+    2,2,2,2,2,2,2,2,  // c8 - cf
+    2,2,2,2,2,2,2,2,  // d0 - d7
+    2,2,2,2,2,2,2,2,  // d8 - df
+    2,2,2,2,2,2,2,2,  // e0 - e7
+    2,2,2,2,2,2,2,2,  // e8 - ef
+    2,2,2,2,2,2,2,2,  // f0 - f7
+    2,2,2,2,2,2,2,2   // f8 - ff
 ];
 
 with( jschardet.Constants )
 jschardet.ISO2022JP_st = [
-    start,    3,error,start,start,start,start,start, // 00-07 
-    start,start,error,error,error,error,error,error, // 08-0f 
-    error,error,error,error,itsMe,itsMe,itsMe,itsMe, // 10-17 
-    itsMe,itsMe,itsMe,itsMe,itsMe,itsMe,error,error, // 18-1f 
-    error,    5,error,error,error,    4,error,error, // 20-27 
-    error,error,error,    6,itsMe,error,itsMe,error, // 28-2f 
-    error,error,error,error,error,error,itsMe,itsMe, // 30-37 
-    error,error,error,itsMe,error,error,error,error, // 38-3f 
-    error,error,error,error,itsMe,error,start,start  // 40-47 
+    start,    3,error,start,start,start,start,start, // 00-07
+    start,start,error,error,error,error,error,error, // 08-0f
+    error,error,error,error,itsMe,itsMe,itsMe,itsMe, // 10-17
+    itsMe,itsMe,itsMe,itsMe,itsMe,itsMe,error,error, // 18-1f
+    error,    5,error,error,error,    4,error,error, // 20-27
+    error,error,error,    6,itsMe,error,itsMe,error, // 28-2f
+    error,error,error,error,error,error,itsMe,itsMe, // 30-37
+    error,error,error,itsMe,error,error,error,error, // 38-3f
+    error,error,error,error,itsMe,error,start,start  // 40-47
 ];
 
 jschardet.ISO2022JPCharLenTable = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -200,47 +200,47 @@ jschardet.ISO2022JPSMModel = {
 };
 
 jschardet.ISO2022KR_cls = [
-    2,0,0,0,0,0,0,0,  // 00 - 07 
-    0,0,0,0,0,0,0,0,  // 08 - 0f 
-    0,0,0,0,0,0,0,0,  // 10 - 17 
-    0,0,0,1,0,0,0,0,  // 18 - 1f 
-    0,0,0,0,3,0,0,0,  // 20 - 27 
-    0,4,0,0,0,0,0,0,  // 28 - 2f 
-    0,0,0,0,0,0,0,0,  // 30 - 37 
-    0,0,0,0,0,0,0,0,  // 38 - 3f 
-    0,0,0,5,0,0,0,0,  // 40 - 47 
-    0,0,0,0,0,0,0,0,  // 48 - 4f 
-    0,0,0,0,0,0,0,0,  // 50 - 57 
-    0,0,0,0,0,0,0,0,  // 58 - 5f 
-    0,0,0,0,0,0,0,0,  // 60 - 67 
-    0,0,0,0,0,0,0,0,  // 68 - 6f 
-    0,0,0,0,0,0,0,0,  // 70 - 77 
-    0,0,0,0,0,0,0,0,  // 78 - 7f 
-    2,2,2,2,2,2,2,2,  // 80 - 87 
-    2,2,2,2,2,2,2,2,  // 88 - 8f 
-    2,2,2,2,2,2,2,2,  // 90 - 97 
-    2,2,2,2,2,2,2,2,  // 98 - 9f 
-    2,2,2,2,2,2,2,2,  // a0 - a7 
-    2,2,2,2,2,2,2,2,  // a8 - af 
-    2,2,2,2,2,2,2,2,  // b0 - b7 
-    2,2,2,2,2,2,2,2,  // b8 - bf 
-    2,2,2,2,2,2,2,2,  // c0 - c7 
-    2,2,2,2,2,2,2,2,  // c8 - cf 
-    2,2,2,2,2,2,2,2,  // d0 - d7 
-    2,2,2,2,2,2,2,2,  // d8 - df 
-    2,2,2,2,2,2,2,2,  // e0 - e7 
-    2,2,2,2,2,2,2,2,  // e8 - ef 
-    2,2,2,2,2,2,2,2,  // f0 - f7 
-    2,2,2,2,2,2,2,2   // f8 - ff 
+    2,0,0,0,0,0,0,0,  // 00 - 07
+    0,0,0,0,0,0,0,0,  // 08 - 0f
+    0,0,0,0,0,0,0,0,  // 10 - 17
+    0,0,0,1,0,0,0,0,  // 18 - 1f
+    0,0,0,0,3,0,0,0,  // 20 - 27
+    0,4,0,0,0,0,0,0,  // 28 - 2f
+    0,0,0,0,0,0,0,0,  // 30 - 37
+    0,0,0,0,0,0,0,0,  // 38 - 3f
+    0,0,0,5,0,0,0,0,  // 40 - 47
+    0,0,0,0,0,0,0,0,  // 48 - 4f
+    0,0,0,0,0,0,0,0,  // 50 - 57
+    0,0,0,0,0,0,0,0,  // 58 - 5f
+    0,0,0,0,0,0,0,0,  // 60 - 67
+    0,0,0,0,0,0,0,0,  // 68 - 6f
+    0,0,0,0,0,0,0,0,  // 70 - 77
+    0,0,0,0,0,0,0,0,  // 78 - 7f
+    2,2,2,2,2,2,2,2,  // 80 - 87
+    2,2,2,2,2,2,2,2,  // 88 - 8f
+    2,2,2,2,2,2,2,2,  // 90 - 97
+    2,2,2,2,2,2,2,2,  // 98 - 9f
+    2,2,2,2,2,2,2,2,  // a0 - a7
+    2,2,2,2,2,2,2,2,  // a8 - af
+    2,2,2,2,2,2,2,2,  // b0 - b7
+    2,2,2,2,2,2,2,2,  // b8 - bf
+    2,2,2,2,2,2,2,2,  // c0 - c7
+    2,2,2,2,2,2,2,2,  // c8 - cf
+    2,2,2,2,2,2,2,2,  // d0 - d7
+    2,2,2,2,2,2,2,2,  // d8 - df
+    2,2,2,2,2,2,2,2,  // e0 - e7
+    2,2,2,2,2,2,2,2,  // e8 - ef
+    2,2,2,2,2,2,2,2,  // f0 - f7
+    2,2,2,2,2,2,2,2   // f8 - ff
 ];
 
 with( jschardet.Constants )
 jschardet.ISO2022KR_st = [
-    start,    3,error,start,start,start,error,error, // 00-07 
-    error,error,error,error,itsMe,itsMe,itsMe,itsMe, // 08-0f 
-    itsMe,itsMe,error,error,error,    4,error,error, // 10-17 
-    error,error,error,error,    5,error,error,error, // 18-1f 
-    error,error,error,itsMe,start,start,start,start  // 20-27 
+    start,    3,error,start,start,start,error,error, // 00-07
+    error,error,error,error,itsMe,itsMe,itsMe,itsMe, // 08-0f
+    itsMe,itsMe,error,error,error,    4,error,error, // 10-17
+    error,error,error,error,    5,error,error,error, // 18-1f
+    error,error,error,itsMe,start,start,start,start  // 20-27
 ];
 
 jschardet.ISO2022KRCharLenTable = [0, 0, 0, 0, 0, 0];
@@ -253,4 +253,4 @@ jschardet.ISO2022KRSMModel = {
     "name"          : "ISO-2022-KR"
 };
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/eucjpprober.js
+++ b/src/eucjpprober.js
@@ -99,4 +99,4 @@ jschardet.EUCJPProber = function() {
 }
 jschardet.EUCJPProber.prototype = new jschardet.MultiByteCharSetProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/euckrfreq.js
+++ b/src/euckrfreq.js
@@ -598,4 +598,4 @@ jschardet.EUCKRCharToFreqOrder = [
 8736,8737,8738,8739,8740,8741
 ];
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/euckrprober.js
+++ b/src/euckrprober.js
@@ -48,4 +48,4 @@ jschardet.EUCKRProber = function() {
 }
 jschardet.EUCKRProber.prototype = new jschardet.MultiByteCharSetProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/euctwfreq.js
+++ b/src/euctwfreq.js
@@ -430,4 +430,4 @@ jschardet.EUCTWCharToFreqOrder = [
 8726,8727,8728,8729,8730,8731,8732,8733,8734,8735,8736,8737,8738,8739,8740,8741
 ]; // 8742
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/euctwprober.js
+++ b/src/euctwprober.js
@@ -48,4 +48,4 @@ jschardet.EUCTWProber = function() {
 }
 jschardet.EUCTWProber.prototype = new jschardet.MultiByteCharSetProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/gb2312freq.js
+++ b/src/gb2312freq.js
@@ -474,4 +474,4 @@ jschardet.GB2312CharToFreqOrder = [
 4866,4899,6099,6100,5559,6478,6765,3599,5868,6101,5869,5870,6275,6766,4527,6767
 ];
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/gb2312prober.js
+++ b/src/gb2312prober.js
@@ -48,4 +48,4 @@ jschardet.GB2312Prober = function() {
 }
 jschardet.GB2312Prober.prototype = new jschardet.MultiByteCharSetProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/hebrewprober.js
+++ b/src/hebrewprober.js
@@ -319,4 +319,4 @@ if (!Array.prototype.indexOf)
     };
 }
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/init.js
+++ b/src/init.js
@@ -15,12 +15,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/init.js
+++ b/src/init.js
@@ -15,12 +15,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- *
+ * 
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/jisfreq.js
+++ b/src/jisfreq.js
@@ -570,4 +570,4 @@ jschardet.JISCharToFreqOrder = [
 8256,8257,8258,8259,8260,8261,8262,8263,8264,8265,8266,8267,8268,8269,8270,8271 // 8272
 ];
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/jpcntx.js
+++ b/src/jpcntx.js
@@ -239,4 +239,4 @@ jschardet.EUCJPContextAnalysis = function() {
 }
 jschardet.EUCJPContextAnalysis.prototype = new jschardet.JapaneseContextAnalysis();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/langbulgarianmodel.js
+++ b/src/langbulgarianmodel.js
@@ -229,4 +229,4 @@ jschardet.Win1251BulgarianModel = {
     "charsetName"           : "windows-1251"
 };
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/langcyrillicmodel.js
+++ b/src/langcyrillicmodel.js
@@ -330,4 +330,4 @@ jschardet.Ibm855Model = {
     "charsetName"             : "IBM855"
 };
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/langgreekmodel.js
+++ b/src/langgreekmodel.js
@@ -226,4 +226,4 @@ jschardet.Win1253GreekModel = {
     "charsetName"           : "windows-1253"
 };
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/langhebrewmodel.js
+++ b/src/langhebrewmodel.js
@@ -200,4 +200,4 @@ jschardet.Win1255HebrewModel = {
     "charsetName"           : "windows-1255"
 };
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/langhungarianmodel.js
+++ b/src/langhungarianmodel.js
@@ -226,4 +226,4 @@ jschardet.Win1250HungarianModel = {
     "charsetName"           : "windows-1250"
 };
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/langthaimodel.js
+++ b/src/langthaimodel.js
@@ -201,4 +201,4 @@ jschardet.TIS620ThaiModel = {
     "charsetName"           : "TIS-620"
 };
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/latin1prober.js
+++ b/src/latin1prober.js
@@ -160,4 +160,4 @@ jschardet.Latin1Prober = function() {
 }
 jschardet.Latin1Prober.prototype = new jschardet.CharSetProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/mbcharsetprober.js
+++ b/src/mbcharsetprober.js
@@ -98,4 +98,4 @@ jschardet.MultiByteCharSetProber = function() {
 }
 jschardet.MultiByteCharSetProber.prototype = new jschardet.CharSetProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/mbcsgroupprober.js
+++ b/src/mbcsgroupprober.js
@@ -44,4 +44,4 @@ jschardet.MBCSGroupProber = function() {
 }
 jschardet.MBCSGroupProber.prototype = new jschardet.CharSetGroupProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/mbcssm.js
+++ b/src/mbcssm.js
@@ -560,4 +560,4 @@ jschardet.UTF8SMModel = {
     "name"          : "UTF-8"
 };
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/sbcharsetprober.js
+++ b/src/sbcharsetprober.js
@@ -136,4 +136,4 @@ jschardet.SingleByteCharSetProber = function(model, reversed, nameProber) {
 }
 jschardet.SingleByteCharSetProber.prototype = new jschardet.CharSetProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/sbcsgroupprober.js
+++ b/src/sbcsgroupprober.js
@@ -63,4 +63,4 @@ jschardet.SBCSGroupProber = function() {
 }
 jschardet.SBCSGroupProber.prototype = new jschardet.CharSetGroupProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/sjisprober.js
+++ b/src/sjisprober.js
@@ -98,4 +98,4 @@ jschardet.SJISProber = function() {
 }
 jschardet.SJISProber.prototype = new jschardet.MultiByteCharSetProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/universaldetector.js
+++ b/src/universaldetector.js
@@ -207,4 +207,4 @@ jschardet.UniversalDetector = function() {
     init();
 }
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);

--- a/src/utf8prober.js
+++ b/src/utf8prober.js
@@ -92,4 +92,4 @@ jschardet.UTF8Prober = function() {
 }
 jschardet.UTF8Prober.prototype = new jschardet.CharSetProber();
 
-}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? module.parent.exports : jschardet);
+}((typeof process !== 'undefined' && typeof process.title !== 'undefined') ? require('./init') : jschardet);


### PR DESCRIPTION
Webpack does not implement the module.parent syntax (cf https://github.com/webpack/webpack/issues/20), so this pull request replaces each instance of module.parent.export with simply require('./init')