### PR TITLE
Fix chardet link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 JsChardet
 =========
 
-Port of python's chardet (http://chardet.feedparser.org/).
+Port of python's chardet (https://github.com/chardet/chardet).
 
 License
 -------


### PR DESCRIPTION
The old link points to a GoDaddy domain parking page.