### PR TITLE
fix error in strict mode

### DIFF
--- a/src/latin1prober.js
+++ b/src/latin1prober.js
@@ -132,6 +132,9 @@ jschardet.Latin1Prober = function() {
     }
 
     this.getConfidence = function() {
+        var confidence;
+        var constants;
+        
         if( this.getState() == jschardet.Constants.notMe ) {
             return 0.01;
         }


### PR DESCRIPTION
We need to declare the variables in order to run in strict mode (node v7 tested)