### PR TITLE
Added filterWithEnglishLetters function for CharSetProber

### DIFF
--- a/dist/jschardet.js
+++ b/dist/jschardet.js
@@ -1465,11 +1465,36 @@ jschardet.CharSetProber = function() {
     }
 
     this.filterWithEnglishLetters = function(aBuf) {
-        /* Returns a copy of ``buf`` that retains only the sequences of English
-           alphabet and high byte characters that are not between <> characters. */
-        var aBufWithTagsRemoved = aBuf.replace( /(<([^>]+)>)/ig, "");
-        var aBufOnlyEnglishLetters = aBufWithTagsRemoved.replace(/[^A-Za-z]+/g, " ");
-        return aBufOnlyEnglishLetters;
+        var result = '';
+        var inTag = false;
+        var prev = 0;
+
+        for (var curr = 0; curr < aBuf.length; curr++) {
+          var c = aBuf[curr];
+
+          if (c == '>') {
+            inTag = false;
+          } else if (c == '<') {
+            inTag = true;
+          }
+
+          var isAlpha = /[a-zA-Z]/.test(c);
+          var isASCII = /^[\x00-\x7F]*$/.test(c);
+
+          if (isASCII && !isAlpha) {
+            if (curr > prev && !inTag) {
+              result = result + aBuf.substring(prev, curr) + ' ';
+            }
+
+            prev = curr + 1;
+          }
+        }
+
+        if (!inTag) {
+          result = result + aBuf.substring(prev);
+        }
+
+        return result;
     }
 }
 

--- a/dist/jschardet.js
+++ b/dist/jschardet.js
@@ -1465,8 +1465,11 @@ jschardet.CharSetProber = function() {
     }
 
     this.filterWithEnglishLetters = function(aBuf) {
-        // TODO
-        return aBuf;
+        /* Returns a copy of ``buf`` that retains only the sequences of English
+           alphabet and high byte characters that are not between <> characters. */
+        var aBufWithTagsRemoved = aBuf.replace( /(<([^>]+)>)/ig, "");
+        var aBufOnlyEnglishLetters = aBufWithTagsRemoved.replace(/[^A-Za-z]+/g, " ");
+        return aBufOnlyEnglishLetters;
     }
 }
 
@@ -6537,7 +6540,7 @@ jschardet.Latin1Prober = function() {
     this.getConfidence = function() {
         var confidence;
         var constants;
-        
+
         if( this.getState() == jschardet.Constants.notMe ) {
             return 0.01;
         }

--- a/src/charsetprober.js
+++ b/src/charsetprober.js
@@ -59,9 +59,41 @@ jschardet.CharSetProber = function() {
         return aBuf;
     }
 
+    // Input: aBuf is a string containing all different types of characters
+    // Output: a string that contains all alphabetic letters, high-byte characters, and word immediately preceding `>`, but nothing else within `<>`
+    // Ex: input - '¡£º <div blah blah> abcdef</div> apples! * and oranges 9jd93jd>'
+    //     output - '¡£º blah div apples and oranges jd jd '
     this.filterWithEnglishLetters = function(aBuf) {
-        // TODO
-        return aBuf;
+        var result = '';
+        var inTag = false;
+        var prev = 0;
+
+        for (var curr = 0; curr < aBuf.length; curr++) {
+          var c = aBuf[curr];
+
+          if (c == '>') {
+            inTag = false;
+          } else if (c == '<') {
+            inTag = true;
+          }
+
+          var isAlpha = /[a-zA-Z]/.test(c);
+          var isASCII = /^[\x00-\x7F]*$/.test(c);
+
+          if (isASCII && !isAlpha) {
+            if (curr > prev && !inTag) {
+              result = result + aBuf.substring(prev, curr) + ' ';
+            }
+
+            prev = curr + 1;
+          }
+        }
+
+        if (!inTag) {
+          result = result + aBuf.substring(prev);
+        }
+
+        return result;
     }
 }
 


### PR DESCRIPTION
Hi, I noticed this TODO when looking through `node` and wanted to work on it. Since `filterWithoutEnglishLetters` replaced all english letters with a space, I assumed `filterWithEnglishLetter` replaced all non-english letters with a space and that is what my change does. Please correct me or close my PR if my understanding of the function is wrong. 