### PR TITLE
Add support for UTF-8 emoji

### DIFF
--- a/src/mbcssm.js
+++ b/src/mbcssm.js
@@ -531,7 +531,7 @@ jschardet.UTF8_st = [
     consts.error,consts.error,consts.error,consts.error,consts.error,consts.error,consts.error,consts.error, //68-6f
     consts.error,consts.error,    9,    9,    9,    9,consts.error,consts.error, //70-77
     consts.error,consts.error,consts.error,consts.error,consts.error,consts.error,consts.error,consts.error, //78-7f
-    consts.error,consts.error,consts.error,consts.error,consts.error,    9,consts.error,consts.error, //80-87
+    consts.error,consts.error,consts.error,consts.error,    9,    9,consts.error,consts.error, //80-87
     consts.error,consts.error,consts.error,consts.error,consts.error,consts.error,consts.error,consts.error, //88-8f
     consts.error,consts.error,   12,   12,   12,   12,consts.error,consts.error, //90-97
     consts.error,consts.error,consts.error,consts.error,consts.error,consts.error,consts.error,consts.error, //98-9f


### PR DESCRIPTION
The original UTF-8 state tables where built before unicode emojis were introduced.
This change updates the state table to handle the unicode emojis for UTF-8.

For example, to recognize the UTF-8 spouting whale emoji:
jschardet.detect(new Buffer("f09f90b3", "hex"));
