### PR TITLE
Add index.d.ts types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+export interface IDetectedMap {
+    encoding: string,
+    confidence: number
+}
+export function detect(buffer: Buffer, options?: { minimumThreshold: number }): IDetectedMap;
+
+export const Constants: {
+    MINIMUM_THRESHOLD: number,
+}
+
+export function enableDebug(): void;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "type": "git",
         "url": "https://github.com/aadsm/jschardet.git"
     },
+    "types": "index.d.ts",
     "directories": {
         "lib": "./lib",
         "test": "./test"


### PR DESCRIPTION
This allows VSCode to remove its copy of `jschardet.d.ts`.

Refs: https://github.com/microsoft/vscode/issues/83421