### PR TITLE
index.d.ts: remove constants

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,8 +4,4 @@ export interface IDetectedMap {
 }
 export function detect(buffer: Buffer, options?: { minimumThreshold: number }): IDetectedMap;
 
-export const Constants: {
-    MINIMUM_THRESHOLD: number,
-}
-
 export function enableDebug(): void;


### PR DESCRIPTION
It looks like there is no longer constants, but rather the confidence is passed in to the detect method. Correcting my previous wrong index.d.ts. 