### PR TITLE
adjust type definitions to allow browser usage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,6 @@ export interface IDetectedMap {
     encoding: string,
     confidence: number
 }
-export function detect(buffer: Buffer, options?: { minimumThreshold: number }): IDetectedMap;
+export function detect(buffer: Buffer | string, options?: { minimumThreshold: number }): IDetectedMap;
 
 export function enableDebug(): void;


### PR DESCRIPTION
Hello!

Current type definitions expect `Buffer`, however implementation does not require it. Since the library [supports browsers](https://github.com/aadsm/jschardet#browser), type definitions need to be more relaxed to allow browser usage without compilation errors :)