### PR TITLE
Add main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "lib": "./lib",
         "test": "./test"
     },
+    "main": "./dist/jschardet.min.js",
     "dependencies": {},
     "devDependencies": {
         "browserify": "~12.0.1",


### PR DESCRIPTION
The main field was missing from the package.json that was stopping me from requiring jschardet when bundled in a .asar