### PR TITLE
Add regression test for GB18030 detection (issue #49)

### DIFF
--- a/scripts/compare-with-chardet.js
+++ b/scripts/compare-with-chardet.js
@@ -14,6 +14,7 @@
 // Auto-runs `npm run build` if build/index.js is missing.
 //
 // See also: scripts/diagnose-file.js for port-only ranking.
+import { readFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';

--- a/tests/fixtures/gb18030-userdb_panda.yar.txt
+++ b/tests/fixtures/gb18030-userdb_panda.yar.txt
@@ -1,0 +1,5 @@
+		description = "PcShare 文件捆绑器 v4.0 -> 无可非议"
+		description = "FreePascal 2.0.0 Win32 -> (B閞czi G醔or, Pierre Muller & Peter Vreman)"
+		description = "E游地带-> 月黑风高"
+		description = "UPX-SCRAMBLER 3.06 -> ㎡nT畂L"
+		description = "心奇EXE合并器 -> yy66"

--- a/tests/jschardet.test.ts
+++ b/tests/jschardet.test.ts
@@ -10,6 +10,7 @@ import windows1250Ro from './fixtures/windows-1250-ro.srt?uint8array';
 import shiftJisCp932Rare from './fixtures/Shift_JIS-cp932-rare.txt?uint8array';
 import shiftJisParticleSakura from './fixtures/Shift_JIS-particle_sakura.txt?uint8array';
 import gb2312Untitled from './fixtures/gb2312-untitled.txt?uint8array';
+import gb18030UserdbPanda from './fixtures/gb18030-userdb_panda.yar.txt?uint8array';
 import iso88591Pt from './fixtures/iso-8859-1-pt.txt?uint8array';
 import utf8StripSh from './fixtures/utf-8-strip.sh.txt?uint8array';
 
@@ -118,6 +119,20 @@ describe('Bug regressions', () => {
   test.fails('GB2312 repeated kanji detects as a Chinese encoding (issue #34)', () => {
     const all = detectAll(gb2312Untitled);
     expect(all[0].language).toBe('zh');
+  });
+
+  // issue #49 (2018, via Atom): the reporter's userdb_panda.yar — GB-encoded
+  // yara rules whose Chinese descriptions use characters beyond GB2312 — was
+  // labeled GB2312 @0.99 by jschardet 3.x, so `iconv -f GB2312` failed on it.
+  // The fixture is the file's Chinese description lines (GB18030-encoded,
+  // undecodable as GB2312). The rewrite unifies the GB family and only reports
+  // the GB18030 superset; confidence is low (~0.04, matching upstream chardet)
+  // because the sample is short, so encoding + language is the regression
+  // surface.
+  test('GB text beyond GB2312 reports GB18030, never GB2312 (issue #49)', () => {
+    const result = detect(gb18030UserdbPanda);
+    expect(result.encoding).toBe('GB18030');
+    expect(result.language).toBe('zh');
   });
 
   // issue #64 (bpasero, 2020): the reporter's strip.sh — UTF-8 shell output


### PR DESCRIPTION
## Summary

Adds a regression test to ensure that GB-encoded text containing characters beyond the GB2312 subset is correctly detected as GB18030 rather than GB2312. This addresses issue #49, where a file with GB18030-encoded Chinese descriptions was incorrectly labeled as GB2312 by jschardet 3.x, causing downstream decoding failures.

## Changes

- **Test fixture**: Added `tests/fixtures/gb18030-userdb_panda.yar.txt` containing GB18030-encoded Chinese text (the description lines from the original `userdb_panda.yar` file that triggered the issue)
- **Test case**: Added `GB text beyond GB2312 reports GB18030, never GB2312 (issue #49)` to verify:
  - Encoding is detected as `GB18030` (the superset that can decode all GB2312 text plus additional characters)
  - Language is correctly identified as `zh` (Chinese)
- **Minor cleanup**: Added missing `readFileSync` import to `scripts/compare-with-chardet.js`

## Implementation Details

The test validates that the port's unified GB family handling (which reports only the GB18030 superset rather than GB2312) correctly handles text with characters outside the GB2312 range. This prevents the regression where files would be mislabeled and subsequently fail to decode with `iconv -f GB2312`.